### PR TITLE
fix: github pages are not deployed

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         needs: build
-        if: github.event == 'push'
+        if: github.event_name == 'push'
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
变量名使用错误,导致deploy流程没有执行

Log: